### PR TITLE
feat: 兼容 testMatch 参数为字符串, 且支持数组形式

### DIFF
--- a/packages/build-scripts/src/commands/test.ts
+++ b/packages/build-scripts/src/commands/test.ts
@@ -5,6 +5,7 @@ import Context, { IContextOptions } from '../core/Context';
 import fs = require('fs-extra')
 import path = require('path')
 import log = require('../utils/log')
+import { ensureTestMatchArray } from '../utils/jestArgv';
 
 export = async function({
   args,
@@ -82,6 +83,7 @@ export = async function({
   Object.freeze(jestConfig);
   await applyHook(`before.${command}.run`, { args, config: jestConfig });
 
+  ensureTestMatchArray(restArgv);
   const result = await new Promise((resolve, reject): void => {
     jest.runCLI(
       {

--- a/packages/build-scripts/src/utils/jestArgv.ts
+++ b/packages/build-scripts/src/utils/jestArgv.ts
@@ -1,0 +1,10 @@
+export function ensureTestMatchArray(argv) {
+  const { testMatch } = argv;
+  if (typeof testMatch === 'string') {
+    if (/^\[.+\]$/.test(testMatch)) {
+      argv.testMatch = JSON.parse(testMatch.replace(/'/g, '"'));
+    } else {
+      argv.testMatch = [testMatch];
+    }
+  }
+}


### PR DESCRIPTION
1. 字符串形式
```
tnpm test -- --jest-testMatch='**/project.test.ts'
```

2. 数组形式
```
tnpm test -- --jest-testMatch='["**/project.test.ts", "**/node.add.test.ts"]'  // or
tnpm test -- --jest-testMatch="['**/project.test.ts', '**/node.add.test.ts']"
```