### PR TITLE
feat: 启动https服务时使用trusted-cert工具来自动生成证书并添加到系统信任

### DIFF
--- a/packages/build-scripts/package.json
+++ b/packages/build-scripts/package.json
@@ -39,7 +39,8 @@
     "semver": "^7.3.2",
     "webpack": "^4.27.1",
     "webpack-dev-server": "^3.7.2",
-    "yargs-parser": "^14.0.0"
+    "yargs-parser": "^14.0.0",
+    "trusted-cert": "^1.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",

--- a/packages/build-scripts/src/commands/start.ts
+++ b/packages/build-scripts/src/commands/start.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import Context, { CommandArgs, IGetBuiltInPlugins, IPluginList, ITaskConfig } from '../core/Context';
 import webpackStats from '../utils/webpackStats';
+import { certificateFor } from 'trusted-cert';
 
 import deepmerge  = require('deepmerge')
 import WebpackDevServer = require('webpack-dev-server')
@@ -74,6 +75,17 @@ export = async function({
     if (process.env.USE_CLI_PORT) {
       devServerConfig.port = args.port;
     }
+  }
+
+  if (devServerConfig.https) {
+    try {
+      const { key, cert } = await certificateFor(devServerConfig.host);
+      devServerConfig = {
+        ...devServerConfig,
+        https: { key, cert },
+      };
+    // eslint-disable-next-line no-empty
+    } catch (error) { }
   }
 
   const webpackConfig = configArr.map(v => v.chainConfig.toConfig());


### PR DESCRIPTION
使用的工具：https://www.npmjs.com/package/trusted-cert
测试结果：
![image](https://user-images.githubusercontent.com/4319405/115481986-3db94e00-a280-11eb-8bd6-c039cd03302c.png)

注意：
启动https服务使用自签名证书，要指定域名如localhost，不能直接访问 127.0.0.1
