### PR TITLE
feat:pass-stats-to-err

### DIFF
--- a/packages/build-scripts/src/commands/build.ts
+++ b/packages/build-scripts/src/commands/build.ts
@@ -99,7 +99,9 @@ export = async function({
           stats,
         });
       } else {
-        reject(new Error('webpack compile error'));
+        const err = new Error('webpack compile error');
+        err.stats = stats;
+        reject(err);
       }
     });
   });


### PR DESCRIPTION
Pass stats to error object for caller to handle webpack stats info, which may provide assistant message for debugging error.