### PR TITLE
fix: check built-in plugins

### DIFF
--- a/packages/build-scripts/src/utils/checkPlugin.ts
+++ b/packages/build-scripts/src/utils/checkPlugin.ts
@@ -7,11 +7,10 @@ const checkPluginValue = (plugins: PluginList): void => {
     flag = false;
   } else {
     flag = plugins.every((v) => {
-      let correct = _.isArray(v) || _.isString(v) || _.isFunction(v);
+      let correct = _.isArray(v) || _.isString(v) || _.isFunction(v) || _.isObject(v);
       if (correct && _.isArray(v)) {
         correct = _.isString(v[0]);
       }
-
       return correct;
     });
   }


### PR DESCRIPTION
Built-in plugins may be an object:
```js
{
  name: '',
  setup: () => {},
  runtime: '',
}
```