### PR TITLE
feat: show stats error when process.env.DEBUG

### DIFF
--- a/packages/build-scripts/src/service/build.ts
+++ b/packages/build-scripts/src/service/build.ts
@@ -72,6 +72,20 @@ export = async function(context: Context, options?: IRunOptions): Promise<void |
           stats,
         });
       } else {
+        // @ts-ignore
+        if (process.env.DEBUG) {
+          const errorCompilations = stats?.stats?.map((s: any) => s.compilation && s.compilation.errors && s.compilation.errors.length ? s.compilation : null).filter((a: any) => a);
+          if (errorCompilations.length) {
+            console.log('\nStats error');
+            errorCompilations.forEach((c: any) => {
+              console.log(`Webpack task ${c.name} compile error`);
+              c.errors.forEach((err: any) => {
+                console.log(err);
+              });
+            });
+            console.log('');
+          }
+        }
         reject(new Error('webpack compile error'));
       }
     });


### PR DESCRIPTION
Rax 编译时方案小程序构建场景下，jsx2mp-loader、jsx-compiler层面的错误往往展示的只是一个"webpack compile error"，而实际的错误是在 stats 的 errors 里，目前一线开发者遇到后不知道怎么查（堆栈只暴露到了 build-script 这一层）。

故，增加 DEBUG 环境变量，开启的情况下可以将 stats 的报错也打印出来，便于定位真实错误。